### PR TITLE
Electrum 4.0.3 upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,10 @@ migration:
 
 regtest:
 	rm -rf ~/.electrum/regtest
-	BTC_DEBUG=true BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true BTC_LIGHTNING_LISTEN=0.0.0.0:9735 python3 daemons/btc.py
+	BTC_DEBUG=true BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true python3 daemons/btc.py
+
+regtestln:
+	BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true BTC_LIGHTNING_LISTEN=0.0.0.0:9735 BTC_PORT=5110 python3 daemons/btc.py
 
 testnet:
 	BTC_DEBUG=true BTC_NETWORK=testnet BTC_LIGHTNING=true python3 daemons/btc.py

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ regtest:
 	BTC_DEBUG=true BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true python3 daemons/btc.py
 
 regtestln:
-	BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true BTC_LIGHTNING_LISTEN=0.0.0.0:9735 BTC_PORT=5110 python3 daemons/btc.py
+	BTC_DATA_PATH=/tmp/bitcartln BTC_NETWORK=regtest BTC_SERVER=127.0.0.1:51001:t BTC_LIGHTNING=true BTC_LIGHTNING_LISTEN=0.0.0.0:9735 BTC_PORT=5110 python3 daemons/btc.py
 
 testnet:
 	BTC_DEBUG=true BTC_NETWORK=testnet BTC_LIGHTNING=true python3 daemons/btc.py

--- a/daemons/base.py
+++ b/daemons/base.py
@@ -84,7 +84,15 @@ class BaseDaemon:
         "new_transaction": "new_transaction",
         "payment_received": "new_payment",
     }
-    LIGHTNING_WALLET_METHODS = ["open_channel", "close_channel", "lnpay", "list_channels"]
+    LIGHTNING_WALLET_METHODS = [
+        "add_peer",
+        "nodeid",
+        "add_lightning_request",
+        "open_channel",
+        "close_channel",
+        "lnpay",
+        "list_channels",
+    ]
     NETWORK_MAPPING: dict = {}
 
     def __init__(self):

--- a/daemons/base.py
+++ b/daemons/base.py
@@ -103,6 +103,7 @@ class BaseDaemon:
         # load env variables
         self.env_name = self.name.upper()
         self.config = AutoConfig(search_path="conf")
+        self.DATA_PATH = self.config(f"{self.env_name}_DATA_PATH", default=None)
         self.LOGIN = self.config(f"{self.env_name}_LOGIN", default="electrum")
         self.PASSWORD = self.config(f"{self.env_name}_PASSWORD", default="electrumz")
         self.NET = self.config(f"{self.env_name}_NETWORK", default="mainnet")
@@ -228,6 +229,7 @@ class BaseDaemon:
         config.set_key(self.NET.lower(), True)
 
     def copy_config_settings(self, config, per_wallet=False):
+        config.set_key("electrum_path", self.DATA_PATH)
         self.set_network_in_config(config)
         config.path = config.electrum_path()  # to reflect network settings
         config.user_config = self.electrum.simple_config.read_user_config(config.path)  # reread config

--- a/daemons/base.py
+++ b/daemons/base.py
@@ -92,6 +92,7 @@ class BaseDaemon:
         "close_channel",
         "lnpay",
         "list_channels",
+        "list_peers",
     ]
     NETWORK_MAPPING: dict = {}
     latest_height = -1

--- a/daemons/bch.py
+++ b/daemons/bch.py
@@ -17,6 +17,9 @@ class BCHDaemon(BaseDaemon):
     }
     latest_height = -1
 
+    def register_callbacks(self):
+        self.network.register_callback(self._process_events, self.AVAILABLE_EVENTS)
+
     def configure_logging(self, electrum_config):
         self.electrum.util.set_verbosity(electrum_config.get("verbosity"))
 

--- a/daemons/bch.py
+++ b/daemons/bch.py
@@ -15,7 +15,12 @@ class BCHDaemon(BaseDaemon):
         "mainnet": electrum.networks.set_mainnet,
         "testnet": electrum.networks.set_testnet,
     }
-    latest_height = -1
+    AVAILABLE_EVENTS = ["blockchain_updated", "new_transaction", "payment_received"]
+    EVENT_MAPPING = {
+        "blockchain_updated": "new_block",
+        "new_transaction": "new_transaction",
+        "payment_received": "new_payment",
+    }
 
     def register_callbacks(self):
         self.network.register_callback(self._process_events, self.AVAILABLE_EVENTS)
@@ -50,12 +55,10 @@ class BCHDaemon(BaseDaemon):
         wallet = None
         data = {}
         if event == "new_block":
-            height = self.network.get_local_height()
-            if height > self.latest_height:
-                self.latest_height = height
-                data["height"] = height
-            else:
+            height = self.process_new_block()
+            if not isinstance(height, int):
                 return None, None
+            data["height"] = height
         elif event == "new_transaction":
             tx, wallet = args
             data["tx"] = tx.txid()

--- a/daemons/spec/btc.json
+++ b/daemons/spec/btc.json
@@ -16,7 +16,8 @@
         "Does not start with ln": -32009,
         "Wrong Lightning invoice HRP": -32009,
         "Too short to contain signature": -32009,
-        "No path found": -32010
+        "No path found": -32010,
+        "Lightning not supported in this wallet type": -32011
     },
     "exceptions": {
         "-32601": {
@@ -66,6 +67,10 @@
         "-32010": {
             "exc_name": "NoPathFoundError",
             "docstring": "No path found to pay the invoice"
+        },
+        "-32011": {
+            "exc_name": "LightningUnsupportedError",
+            "docstring": "Lightning not supported in this wallet type"
         }
     }
 }

--- a/requirements/daemons/bch.txt
+++ b/requirements/daemons/bch.txt
@@ -1,2 +1,2 @@
-https://github.com/Electron-Cash/Electron-Cash/archive/c679a7e80d8099b653f00c7611fa43c0a01a027c.zip
+https://github.com/Electron-Cash/Electron-Cash/archive/08b2e4ba226ab0c6b0eae065ea3225336d805f3c.zip
 aiohttp>=3.3.0,<4.0.0

--- a/requirements/daemons/bsty.txt
+++ b/requirements/daemons/bsty.txt
@@ -1,1 +1,1 @@
-https://github.com/GlobalBoost/electrum/archive/32624c8c07a929e2ec4f4cefe83b99cb3c11c018.zip
+https://github.com/GlobalBoost/electrum/archive/6d7c7a1cb5c384377b24391bcbc7b797462b980a.zip#egg=electrum-bsty[crypto]

--- a/requirements/daemons/btc.txt
+++ b/requirements/daemons/btc.txt
@@ -1,1 +1,1 @@
-https://github.com/spesmilo/electrum/archive/1773bd6cd6b9aaa693c6c1cb865f88fc3597e09f.zip # TODO: refer back to stable release when out
+https://github.com/spesmilo/electrum/archive/4.0.3.zip#egg=electrum[crypto]

--- a/requirements/daemons/btc.txt
+++ b/requirements/daemons/btc.txt
@@ -1,1 +1,1 @@
-https://github.com/spesmilo/electrum/archive/4.0.3.zip#egg=electrum[crypto]
+https://github.com/spesmilo/electrum/archive/6bd1a04aee3d1adc052731793e7ebfb5023f7f56.zip#egg=electrum[crypto] # TODO: pin to 4.0.4 when out

--- a/requirements/daemons/gzro.txt
+++ b/requirements/daemons/gzro.txt
@@ -1,1 +1,1 @@
-https://github.com/GZR0/electrum/archive/5dcdfcea5c94d239c44f8b4894dae761d714ce12.zip#egg=electrum-gzro[crypto]
+https://github.com/GZR0/electrum/archive/fddfa11e667ab0481c6271138728de10e54b94d6.zip#egg=electrum-gzro[crypto]

--- a/requirements/daemons/gzro.txt
+++ b/requirements/daemons/gzro.txt
@@ -1,1 +1,1 @@
-https://github.com/GZR0/electrum/archive/fddfa11e667ab0481c6271138728de10e54b94d6.zip#egg=electrum-gzro[crypto]
+https://github.com/GZR0/electrum/archive/ab24613a858897b9ff426b648c78512c35a0c8ef.zip#egg=electrum-gzro[crypto]

--- a/requirements/daemons/gzro.txt
+++ b/requirements/daemons/gzro.txt
@@ -1,1 +1,1 @@
-https://github.com/GZR0/electrum/archive/275e1b21e3ace5918d8319f85251a23c4da25ee6.zip
+https://github.com/GZR0/electrum/archive/5dcdfcea5c94d239c44f8b4894dae761d714ce12.zip#egg=electrum-gzro[crypto]

--- a/requirements/daemons/ltc.txt
+++ b/requirements/daemons/ltc.txt
@@ -1,1 +1,2 @@
-https://github.com/pooler/electrum-ltc/archive/77e06be6e6a7e0746b532661855453ffff0c9381.zip
+https://github.com/pooler/electrum-ltc/archive/1fc26a0fd2bb198b98263573a696433808ca45b3.zip
+scrypt>=0.6.0

--- a/requirements/daemons/ltc.txt
+++ b/requirements/daemons/ltc.txt
@@ -1,2 +1,2 @@
-https://github.com/pooler/electrum-ltc/archive/1fc26a0fd2bb198b98263573a696433808ca45b3.zip
+https://github.com/pooler/electrum-ltc/archive/1fc26a0fd2bb198b98263573a696433808ca45b3.zip#egg=electrum-ltc[crypto]
 scrypt>=0.6.0


### PR DESCRIPTION
This PR upgrades electrum from spesmilo/electrum@1773bd6cd6b9aaa693c6c1cb865f88fc3597e09f to [version 4.0.3](https://github.com/spesmilo/electrum/tree/4.0.3)
[Compare URL](https://github.com/spesmilo/electrum/compare/1773bd6cd6b9aaa693c6c1cb865f88fc3597e09f...4.0.3)

Breaking changes in electrum 4.0, daemon side:
- Lightning wallet methods require segwit wallets only. It might work on old wallet files, but not on new ones. Daemon will now catch calls to lightning methods and raise error before calling actual methods, to be able to show helpful error message instead of AttributeError.
- network.register_callback -> electrum.util.register_callback
- Creating wallet now require creating db object
- get_transaction electrumx call now doesn't return an str, but a dict

This PR adds `COIN_DATA_PATH` setting to change directory used for storing network headers and wallets. Useful for testing.

Breaking changes and questions in SDK: bitcartcc/bitcart-sdk#17

TODO before merging:
- [x] Fix all issues and questions in some SDK tests
- [x] Test if event system still works:
     - [x] payment_received event renamed to request_status, no wallet passed anymore (electrum fix spesmilo/electrum#6595)
- [x] Test if other coins still work
    - [x] GZRO
    - [x] BSTY
    - [x] BCH
    - [x] LTC
- [x] Add some new features added to commands in 4.0
- [x] Migrate other coins electrums to 4.0
     - [x] GZRO
     - [x] LTC
     - [x] BSTY
- [x] Check whether electron cash also needs payto patch
- [x] Submit payto patch to electron cash (https://github.com/Electron-Cash/Electron-Cash/pull/1997)

Note: merging this will break CI until SDK 1.0 is used