### PR TITLE
Fixed some scaling issues

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -131,7 +131,7 @@ shutdown = asyncio.Event(loop=loop)
 async def init_db():
     from . import db
 
-    await db.db.set_bind(db.CONNECTION_STR, min_size=3, max_size=3, loop=loop)
+    await db.db.set_bind(db.CONNECTION_STR, min_size=0, max_size=3, loop=loop)
 
 
 class InitDB(dramatiq.Middleware):

--- a/api/settings.py
+++ b/api/settings.py
@@ -131,7 +131,7 @@ shutdown = asyncio.Event(loop=loop)
 async def init_db():
     from . import db
 
-    await db.db.set_bind(db.CONNECTION_STR, min_size=0, max_size=3, loop=loop)
+    await db.db.set_bind(db.CONNECTION_STR, min_size=1, loop=loop)
 
 
 class InitDB(dramatiq.Middleware):

--- a/api/settings.py
+++ b/api/settings.py
@@ -128,12 +128,16 @@ def run_sync(f):
 shutdown = asyncio.Event(loop=loop)
 
 
+async def init_db():
+    from . import db
+
+    await db.db.set_bind(db.CONNECTION_STR, min_size=3, max_size=3, loop=loop)
+
+
 class InitDB(dramatiq.Middleware):
     def before_worker_boot(self, broker, worker):
         async def run():
-            from . import db
-
-            await db.db.set_bind(db.CONNECTION_STR)
+            await init_db()
 
         loop.run_until_complete(run())
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 
 from api import settings
-from api.db import CONNECTION_STR, db
+from api.db import db
 from api.ext import tor as tor_ext
 from api.utils import run_repeated
 from api.views import router
@@ -34,7 +34,7 @@ async def add_onion_host(request: Request, call_next):
 
 @app.on_event("startup")
 async def startup():
-    await db.set_bind(CONNECTION_STR, min_size=3, max_size=3, loop=settings.loop)
+    await settings.init_db()
     asyncio.ensure_future(run_repeated(tor_ext.refresh, 120, 10))
     if settings.TEST:
         await db.gino.create_all()


### PR DESCRIPTION
This pull request is a partial fix of #134 
Before the PR, dramatiq worker was using 10 connections each, because it was not using same settings as gunicorn worker. They now use same settings.
Also, now by default on startup connections aren't allocated (`min_size=0`), but connections are reserved on requests when needed, so it is possible to run bitcartcc under a lot of cores till it still reaches the 100 connections limit, which means something like 100 concurrent connections to database
But the question is whether it's full solution to the issues or not.