### PR TITLE
Better notifications

### DIFF
--- a/daemons/base.py
+++ b/daemons/base.py
@@ -453,7 +453,7 @@ class BaseDaemon:
         data.update(data_got)
         for i in self.wallets:
             if not wallet or wallet == self.wallets[i]["wallet"]:
-                asyncio.run_coroutine_threadsafe(self.notify_websockets(data, i), self.loop)
+                asyncio.run_coroutine_threadsafe(self.notify_websockets(data, i), self.loop).result()
                 self.wallets_updates[i].append(data)
 
     def process_new_block(self):


### PR DESCRIPTION
This PR introduces a third way of receiving updates: websockets.

Before we didn't consider that as it was too much for a "low-level" daemon. But in fact, it still remains low-level. There is no cors handling or something browser-related. Websockets are for internal usage between services, often on the same server.

Websocket is more useful, as daemon doesn't need to know where to send notifications (it just sends to connected listeners), and client doesn't need to find out their address.

It makes it possible to resolve invoice polling issues in a follow-up PR.
Also, subscription system is removed, event filtering is now passed to SDK. Why? Because SDK only subscribed for registered handlers' events anyway, so it woudn't change anything SDK side, but would reduce complexity of the daemon.

Websocket clients may send a json message, requesting to limit updates to only one xpub (used for coin objects), or instead, all updates on all current wallets are sent (useful for APIManager).

Websocket updates are sent in a performant way, via `asyncio.gather`.

TODO:
- [x] Consider using asyncio.gather for notification sending/wallet processing at a whole (as a whole it can't be parallel because of `wallet_updates` appending order)
- [x] Test edge cases, like sending invalid data or websocket disconnection
- [x] Test which events are sent to which wallets
- [x] Maybe remove webhook method alltogether?

