### PR TITLE
Use redis for event system,  fixes, improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v20-dependencies-{{ checksum "requirements/web.txt" }}-{{ checksum "requirements/test.txt" }}-{{ checksum "requirements/daemons/btc.txt" }}-<< parameters.v >>
+            - v21-dependencies-{{ checksum "requirements/web.txt" }}-{{ checksum "requirements/test.txt" }}-{{ checksum "requirements/daemons/btc.txt" }}-<< parameters.v >>
             # fallback to using the latest cache if no exact match is found
-            - v20-dependencies-
+            - v21-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -40,7 +40,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v20-dependencies-{{ checksum "requirements/web.txt" }}-{{ checksum "requirements/test.txt" }}-{{ checksum "requirements/daemons/btc.txt" }}-<< parameters.v >>
+          key: v21-dependencies-{{ checksum "requirements/web.txt" }}-{{ checksum "requirements/test.txt" }}-{{ checksum "requirements/daemons/btc.txt" }}-<< parameters.v >>
 
       - run:
           name: prepare daemon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Now local deployment via .local domains works as before, and it now modifies /et
 - Fixed logging in docker environment
 - Fixed pagination for id 0
 - Added ability to change fiat currency used in the /rate endpoint
+- Fixed websockets' internal channel ids clash sometimes
 
 ## 0.2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Latest changes
 
+## 0.2.2.0
+
+This release is mostly a bugfix release, but with a few new features too.
+
+### Full invoice tasks handling refactor
+
+Now there is only one expired task created for an invoice, instead of N (where N is the number of payment methods).
+
+It means that BitcartCC should use less RAM, and also there will be less edge cases and duplicate IPN sent.
+
+Also, to handle some rare cases if gunicorn workers are restarting, we have changed the way background tasks are handled.
+
+Technical details:
+The idea is to make every background task, and every asyncio task run in background worker, and not gunicorn ones.
+
+Background worker listens on a redis channel for events, and gunicorn workers publish messages to the channel. Worker parses messages and executes event handlers in separate asyncio tasks.
+
+### Fixed local deployment
+
+Now local deployment via .local domains works as before, and it now modifies /etc/hosts in a clever way, avoiding duplicate entries
+
+### Other changes
+
+- Admin panel now displays a helpful message when invoice has no payment methods connected
+- Fixed recommended fee in case it's unavailable.
+- Tor extension now doesn't log always, instead it logs only warnings if something was misconfigured.
+- Fixed IPN sending
+- Fixed logging in docker environment
+- Fixed pagination for id 0
+- Added ability to change fiat currency used in the /rate endpoint
+
 ## 0.2.1.1
 
 Fix multiple store support on POS

--- a/api/constants.py
+++ b/api/constants.py
@@ -1,6 +1,7 @@
-VERSION = "0.2.1.1"
-WEBSITE = "https://bitcartcc.com"
-GIT_REPO_URL = "https://github.com/bitcartcc/bitcart"
-LOG_FILE_NAME = "bitcart-log.log"
-MAX_CONFIRMATION_WATCH = 6
-FEE_ETA_TARGETS = [25, 10, 5, 2, 1]
+VERSION = "0.2.2.0"  # Version, used for openapi schemas and update checks
+WEBSITE = "https://bitcartcc.com"  # BitcartCC official site
+GIT_REPO_URL = "https://github.com/bitcartcc/bitcart"  # BitcartCC github repository
+LOG_FILE_NAME = "bitcart-log.log"  # base log file name
+MAX_CONFIRMATION_WATCH = 6  # maximum number of confirmations to save
+FEE_ETA_TARGETS = [25, 10, 5, 2, 1]  # supported target blocks confirmation ETA fee
+EVENTS_CHANNEL = "events"  # default redis channel for event system (inter-process communication)

--- a/api/constants.py
+++ b/api/constants.py
@@ -5,3 +5,4 @@ LOG_FILE_NAME = "bitcart-log.log"  # base log file name
 MAX_CONFIRMATION_WATCH = 6  # maximum number of confirmations to save
 FEE_ETA_TARGETS = [25, 10, 5, 2, 1]  # supported target blocks confirmation ETA fee
 EVENTS_CHANNEL = "events"  # default redis channel for event system (inter-process communication)
+LOGSERVER_PORT = 9020  # port for logserver in the worker

--- a/api/events.py
+++ b/api/events.py
@@ -1,0 +1,82 @@
+"""Event system for gunicorn workers/background worker communication via redis pub/sub."""
+
+import asyncio
+
+from pydantic import ValidationError
+
+from . import constants, utils
+
+
+class EventHandler:
+    def __init__(self, events=None):
+        self.events = events or {}
+
+    def add_event(self, name, event):
+        self.events[name] = event
+
+    def add_handler(self, event, handler):
+        if event not in self.events:
+            return False
+        self.events[event]["handlers"].append(handler)
+        return True
+
+    def on(self, event):
+        def wrapper(func):
+            self.add_handler(event, func)
+            return func
+
+        return wrapper
+
+    async def process(self, message):
+        event = message.event
+        data = message.data
+        if event not in self.events:
+            return
+        event_data = self.events[event]
+        if not isinstance(data, dict) or data.keys() != event_data["params"]:
+            return
+        coros = (handler(event, data) for handler in event_data["handlers"])
+        await asyncio.gather(*coros, return_exceptions=False)
+
+    async def publish(self, name, data):
+        await send_message({"event": name, "data": data})
+
+
+async def process_message(message, custom_event_handler=None):
+    from . import schemes
+
+    try:
+        message = schemes.EventSystemMessage(**message)
+    except (TypeError, ValidationError):
+        return
+    custom_event_handler = custom_event_handler or event_handler
+    await custom_event_handler.process(message)
+
+
+async def send_message(message):
+    await utils.publish_message(constants.EVENTS_CHANNEL, message)
+
+
+async def listen(sub, channel, custom_event_handler=None):  # pragma: no cover
+    while await channel.wait_message():
+        msg = await channel.get_json()
+        asyncio.ensure_future(process_message(msg, custom_event_handler))
+
+
+async def start_listening(custom_event_handler=None):  # pragma: no cover
+    subscriber, channel = await utils.make_subscriber(constants.EVENTS_CHANNEL)
+    await listen(subscriber, channel, custom_event_handler)
+
+
+event_handler = EventHandler(
+    events={
+        "expired_task": {
+            "params": {"id"},
+            "handlers": [],
+        },
+        "sync_wallet": {
+            "params": {"id"},
+            "handlers": [],
+        },
+    }
+)

--- a/api/logger.py
+++ b/api/logger.py
@@ -10,7 +10,7 @@ import msgpack
 from pydantic import BaseModel
 from starlette.config import Config
 
-from api.constants import LOG_FILE_NAME
+from api.constants import LOG_FILE_NAME, LOGSERVER_PORT
 
 
 def get_exception_message(exc: Exception):
@@ -79,7 +79,7 @@ logger.addHandler(console)
 logger_client = logging.getLogger("bitcart.logclient")
 logger_client.setLevel(logging.DEBUG)
 
-socket_handler = MsgpackHandler(LOGSERVER_HOST, logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+socket_handler = MsgpackHandler(LOGSERVER_HOST, LOGSERVER_PORT)
 socket_handler.setLevel(logging.DEBUG)
 logger_client.addHandler(socket_handler)
 

--- a/api/logger.py
+++ b/api/logger.py
@@ -60,6 +60,8 @@ class MsgpackHandler(logging.handlers.SocketHandler):
 config = Config("conf/.env")
 LOG_DIR = config("LOG_DIR", default=None)
 LOG_FILE = os.path.join(LOG_DIR, LOG_FILE_NAME) if LOG_DIR else None
+DOCKER_ENV = config("IN_DOCKER", cast=bool, default=False)
+LOGSERVER_HOST = "worker" if DOCKER_ENV else "localhost"
 
 formatter = Formatter(
     "%(asctime)s - [PID %(process)d] - %(name)s.%(funcName)s [line %(lineno)d] - %(levelname)s - %(message)s"
@@ -76,7 +78,8 @@ logger.addHandler(console)
 
 logger_client = logging.getLogger("bitcart.logclient")
 logger_client.setLevel(logging.DEBUG)
-socket_handler = MsgpackHandler("localhost", logging.handlers.DEFAULT_TCP_LOGGING_PORT)
+
+socket_handler = MsgpackHandler(LOGSERVER_HOST, logging.handlers.DEFAULT_TCP_LOGGING_PORT)
 socket_handler.setLevel(logging.DEBUG)
 logger_client.addHandler(socket_handler)
 

--- a/api/logserver.py
+++ b/api/logserver.py
@@ -8,7 +8,8 @@ from decimal import Decimal
 
 import msgpack
 
-from .logger import configure_file_logging
+from .constants import LOGSERVER_PORT
+from .logger import DOCKER_ENV, configure_file_logging
 from .logger import get_logger_server as get_logger
 
 
@@ -41,7 +42,12 @@ class LogRecordStreamHandler(socketserver.StreamRequestHandler):
 class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
     allow_reuse_address = True
 
-    def __init__(self, host="localhost", port=logging.handlers.DEFAULT_TCP_LOGGING_PORT, handler=LogRecordStreamHandler):
+    def __init__(
+        self,
+        host="0.0.0.0" if DOCKER_ENV else "localhost",
+        port=LOGSERVER_PORT,
+        handler=LogRecordStreamHandler,
+    ):
         socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
         self.abort = 0
         self.timeout = 1
@@ -58,7 +64,7 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
             abort = self.abort
 
 
-def wait_for_port(host="localhost", port=logging.handlers.DEFAULT_TCP_LOGGING_PORT, timeout=5.0):
+def wait_for_port(host="localhost", port=LOGSERVER_PORT, timeout=5.0):
     start_time = time.perf_counter()
     while True:
         try:

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -43,7 +43,6 @@ class Pagination:
 
     async def get_count(self, query) -> int:
         query = query.with_only_columns([db.func.count(distinct(self.model.id))]).order_by(None)  # type: ignore
-
         return await query.gino.scalar() or 0
 
     def get_next_url(self, count) -> Union[None, str]:
@@ -54,10 +53,8 @@ class Pagination:
     def get_previous_url(self) -> Union[None, str]:
         if self.offset <= 0:
             return None
-
         if self.offset - self.limit <= 0:
             return str(self.request.url.remove_query_params(keys=["offset"]))
-
         return str(self.request.url.include_query_params(limit=self.limit, offset=self.offset - self.limit))
 
     async def get_list(self, query) -> list:
@@ -131,7 +128,7 @@ class Pagination:
 
     def get_queryset(self, model, user_id, sale, store_id, category, min_price, max_price, app_id, redirect_url, permissions):
         query = self.get_base_query(model, sale)
-        if user_id and model != models.User:
+        if user_id is not None and model != models.User:
             query = query.where(model.user_id == user_id)
         if model == models.Product:
             query = self._filter_in_product(query, store_id, category, min_price, max_price)
@@ -141,13 +138,13 @@ class Pagination:
 
     @staticmethod
     def _filter_in_product(query, store_id, category, min_price, max_price):
-        if store_id:
+        if store_id is not None:
             query = query.where(models.Product.store_id == store_id)
         if category and category != "all":
             query = query.where(models.Product.category == category)
-        if min_price:
+        if min_price is not None:
             query = query.where(models.Product.price >= min_price)
-        if max_price:
+        if max_price is not None:
             query = query.where(models.Product.price <= max_price)
         return query
 
@@ -157,6 +154,6 @@ class Pagination:
             query = query.where(models.Token.app_id == app_id)
         if redirect_url is not None:
             query = query.where(models.Token.redirect_url == redirect_url)
-        if permissions:
+        if permissions is not None:
             query = query.where(models.Token.permissions.contains(permissions))
         return query

--- a/api/schemes.py
+++ b/api/schemes.py
@@ -330,3 +330,8 @@ class CloseChannelScheme(BaseModel):
 
 class LNPayScheme(BaseModel):
     invoice: str
+
+
+class EventSystemMessage(BaseModel):
+    event: str
+    data: dict

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,18 +1,26 @@
-from typing import Union
-
-from . import models, settings, utils
+from . import invoices, models, settings, utils
+from .events import event_handler
 from .logger import get_logger
 
 logger = get_logger(__name__)
 
 
-async def sync_wallet(model: Union[int, models.Wallet]):
-    model = await models.Wallet.get(model)
+@event_handler.on("expired_task")
+async def create_expired_task(event, event_data):
+    invoice = await models.Invoice.get(event_data["id"])
+    if not invoice:
+        return
+    await invoices.make_expired_task(invoice)
+
+
+@event_handler.on("sync_wallet")
+async def sync_wallet(event, event_data):
+    model = await models.Wallet.get(event_data["id"])
     if not model:
         return
     coin = settings.get_coin(model.currency, model.xpub)
     balance = await coin.balance()
     logger.info(f"Wallet {model.id} synced, balance: {balance['confirmed']}")
     await utils.publish_message(
-        model.id, {"status": "success", "balance": str(balance["confirmed"])}
+        f"wallet:{model.id}", {"status": "success", "balance": str(balance["confirmed"])}
     )  # convert for json serialization

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,56 @@
+from queue import Queue
+
+import pytest
+
+from api import events
+
+
+@pytest.fixture
+def empty_event_handler():
+    return events.EventHandler()
+
+
+@pytest.fixture
+def event_handler():
+    return events.EventHandler(events={"test_event": {"params": {"param1", "param2"}, "handlers": []}})
+
+
+def test_add_event_handler(empty_event_handler, event_handler):
+    def func(event, event_data):
+        pass
+
+    assert not empty_event_handler.add_handler("test_event", func)
+    assert not empty_event_handler.events
+    assert event_handler.add_handler("test_event", func)
+    assert len(event_handler.events["test_event"]["handlers"]) == 1
+    assert event_handler.events["test_event"]["handlers"][0] == func
+
+    @event_handler.on("invalid_event")
+    def func2(event, event_data):
+        pass
+
+    assert "invalid_event" not in event_handler.events
+    event_handler.add_event("invalid_event", {"params": {"id"}, "handlers": []})
+    assert event_handler.add_handler("invalid_event", func2)
+    assert len(event_handler.events["invalid_event"]["handlers"]) == 1
+    assert event_handler.events["invalid_event"]["handlers"][0] == func2
+
+
+@pytest.mark.asyncio
+async def test_process_message(event_handler):
+    queue = Queue()
+
+    async def handler(event, event_data):
+        queue.put(event_data)
+
+    event_handler.add_handler("test_event", handler)
+    await events.process_message("test", event_handler)
+    assert queue.empty()
+    await events.process_message({"event": "invalid_event", "data": {}}, event_handler)
+    assert queue.empty()
+    await events.process_message({"event": "test_event", "data": {"test": "test"}}, event_handler)
+    assert queue.empty()
+    sample_data = {"param1": 1, "param2": 2}
+    await events.process_message({"event": "test_event", "data": sample_data}, event_handler)
+    assert queue.qsize() == 1
+    assert queue.get() == sample_data

--- a/worker.py
+++ b/worker.py
@@ -3,7 +3,7 @@ import signal
 import sys
 from multiprocessing import Process
 
-from api import invoices, settings
+from api import events, invoices, settings, tasks
 from api.ext import tor as tor_ext
 from api.ext import update as update_ext
 from api.logserver import main as start_logserver
@@ -16,10 +16,13 @@ async def main():
     settings.log_startup_info()
     await tor_ext.refresh(log=False)  # to pre-load data for initial requests
     await update_ext.refresh()
-    asyncio.ensure_future(run_repeated(tor_ext.refresh, 60 * 15, 10))
+    asyncio.ensure_future(run_repeated(tor_ext.refresh, 60 * 10, 10))
     asyncio.ensure_future(run_repeated(update_ext.refresh, 60 * 60 * 24))
     settings.manager.add_event_handler("new_payment", invoices.new_payment_handler)
     settings.manager.add_event_handler("new_block", invoices.new_block_handler)
+    await invoices.create_expired_tasks()  # to ensure invoices get expired actually
+    coro = events.start_listening(tasks.event_handler)  # to avoid deleted task errors
+    asyncio.ensure_future(coro)
     await settings.manager.start_websocket(reconnect_callback=invoices.check_pending, force_connect=True)
 
 


### PR DESCRIPTION
This PR adds an event system for better inter-process communication.
The idea is to make every background task, and every asyncio task run in background worker, and not gunicorn ones.
Background worker listens on a redis channel for events, and gunicorn workers publish messages to the channel. Worker parses messages and executes event handlers in separate asyncio tasks.
Fixed recommended fee in case it's unavailable.
Now for each invoice only one expired task is created
Tor extension now doesn't log always, instead it logs only warnings if something was misconfigured.
Fixed IPN sending
(Probably) fixed logging in docker environment
Fixed pagination for id 0
Added ability to change fiat currency used in the `/rate` endpoint
